### PR TITLE
inotifywait should use the "close_write" event instead of "create"

### DIFF
--- a/scripts/feedCaronte.sh
+++ b/scripts/feedCaronte.sh
@@ -45,7 +45,7 @@ if [[ -z "$PCAP_DIR" ]]; then
 	exit 2
 fi
 
-inotifywait -m "$PCAP_DIR" -e create -e moved_to |
+inotifywait -m "$PCAP_DIR" -e close_write -e moved_to |
            while read dir action file; do
              echo "The file $file appeared in directory $dir via $action"
              curl -F "file=@$file" "http://localhost:3333/api/pcap/upload"


### PR DESCRIPTION
With the "create" event inotifywait gets triggered as soon as the file is created, which means that if a file is still being transfered for example with scp, inotifywait gets triggered and the file is being submitted to caronte, but the file is incomplete and shows an EOF error. With "close_write" inotifywait gets triggered only when the transfer is completed, so the pcap is fed correctly to caronte

As the inotifywait docs say: 
```
close_write
              A watched file or a file within a watched directory was closed, after being opened in writable mode.  This does not necessarily imply the file was written to.
```