### PR TITLE
fix/wss-over-https

### DIFF
--- a/frontend/src/notifications.js
+++ b/frontend/src/notifications.js
@@ -22,7 +22,7 @@ class Notifications {
 
     constructor() {
         const location = document.location;
-        this.wsUrl = `ws://${location.hostname}${location.port ? ":" + location.port : ""}/ws`;
+ 	    this.wsUrl = `${location.protocol === "https:"? "wss" : "ws"}://${location.hostname}${location.port ? ":" + location.port : ""}/ws`
     }
 
     createWebsocket = () => {

--- a/frontend/src/notifications.js
+++ b/frontend/src/notifications.js
@@ -22,7 +22,7 @@ class Notifications {
 
     constructor() {
         const location = document.location;
- 	    this.wsUrl = `${location.protocol === "https:"? "wss" : "ws"}://${location.hostname}${location.port ? ":" + location.port : ""}/ws`
+ 	    this.wsUrl = `${location.protocol === "https:"? "wss" : "ws"}://${location.hostname}${location.port ? ":" + location.port : ""}/ws`;
     }
 
     createWebsocket = () => {


### PR DESCRIPTION
websocket secure did not work when connecting via https because standard (non secure) websocket was enforced, now websocket protocol is chosen based on the connection protocol:
http:// -> ws://
https:// -> wss://